### PR TITLE
Ensure CLEAN runs tag logs correctly

### DIFF
--- a/MQL4/Experts/EuroScalper_CLEAN.mq4
+++ b/MQL4/Experts/EuroScalper_CLEAN.mq4
@@ -239,7 +239,10 @@ void ES_TryGridAdd()
 
 int init()
 {
-   // Set context BEFORE opening the log so magic appears in filename
+   // Ensure the logger uses the CLEAN run tag and that the
+   // magic number is reflected in the filename before the log
+   // file is opened.
+   ES_Log_RunTag = ES_RUN_TAG;
    ES_Log_SetContext(_Symbol, Period(), Magic);
    ES_Log_OnInit();
    return(0);


### PR DESCRIPTION
## Summary
- set ES_Log_RunTag during init so CLEAN logs include the `_CLEAN` suffix

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68ae7b5c9c348323991875a3f90de100