### PR TITLE
Fix CLEAN EA logger initialization to include end timestamp

### DIFF
--- a/MQL4/Experts/EuroScalper_CLEAN.mq4
+++ b/MQL4/Experts/EuroScalper_CLEAN.mq4
@@ -239,9 +239,11 @@ void ES_TryGridAdd()
 
 int init()
 {
-   // Set context BEFORE opening the log so magic appears in filename
-   ES_Log_SetContext(_Symbol, Period(), Magic);
+   // Use the CLEAN run tag, open the logger once, then attach
+   // symbol/period/magic context without creating a placeholder file.
+   ES_Log_RunTag = ES_RUN_TAG;
    ES_Log_OnInit();
+   ES_Log_SetContext(_Symbol, Period(), Magic);
    return(0);
 }
 


### PR DESCRIPTION
## Summary
- Reorder CLEAN EA logging setup so the logger opens once, then sets context
- Update comments to explain the logger order and avoid placeholder log files

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68ae7b5c9c348323991875a3f90de100