### PR TITLE
Handle multi-line schemas in log comparison tool

### DIFF
--- a/repo/tools/compare_logs.py
+++ b/repo/tools/compare_logs.py
@@ -53,13 +53,17 @@ def read_csv(path, delimiter_override=None):
 def load_schema(schema_path):
     if not schema_path or not os.path.exists(schema_path):
         return None
+    parts = []
     with open(schema_path, "r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
-            cols = [c.strip() for c in line.replace(";", ",").split(",")]
-            return cols
+            parts.append(line)
+    if parts:
+        joined = ",".join(parts)
+        cols = [c.strip() for c in joined.replace(";", ",").split(",") if c.strip()]
+        return cols
     return None
 
 # -------------------------------

--- a/repo/tools/test_compare_logs.py
+++ b/repo/tools/test_compare_logs.py
@@ -1,0 +1,65 @@
+import sys
+import subprocess
+from pathlib import Path
+
+
+TOOLS_DIR = Path(__file__).resolve().parent
+sys.path.append(str(TOOLS_DIR))
+
+import compare_logs  # noqa: E402
+
+
+def test_load_schema_and_headers(tmp_path):
+    schema_path = tmp_path / "schema.txt"
+    schema_path.write_text("""# comment line
+col1,col2
+col3,col4
+""")
+
+    cols = compare_logs.load_schema(str(schema_path))
+    assert cols == ["col1", "col2", "col3", "col4"]
+
+    header = "col1,col2,col3,col4\n"
+    baseline = tmp_path / "baseline.csv"
+    candidate = tmp_path / "candidate.csv"
+    baseline.write_text(header + "1,2,3,4\n")
+    candidate.write_text(header + "1,2,3,4\n")
+
+    result = subprocess.run([
+        sys.executable,
+        str(TOOLS_DIR / "compare_logs.py"),
+        "--baseline", str(baseline),
+        "--candidate", str(candidate),
+        "--schema", str(schema_path),
+        "--align-key", "col1",
+    ], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_header_mismatch_fails(tmp_path):
+    schema_path = tmp_path / "schema.txt"
+    schema_path.write_text("""# schema
+col1,col2
+col3
+""")
+
+    header_ok = "col1,col2,col3\n"
+    header_bad = "col1,col2,colX\n"
+    baseline = tmp_path / "baseline.csv"
+    candidate = tmp_path / "candidate.csv"
+    baseline.write_text(header_ok + "1,2,3\n")
+    candidate.write_text(header_bad + "1,2,3\n")
+
+    result = subprocess.run([
+        sys.executable,
+        str(TOOLS_DIR / "compare_logs.py"),
+        "--baseline", str(baseline),
+        "--candidate", str(candidate),
+        "--schema", str(schema_path),
+        "--align-key", "col1",
+    ], capture_output=True, text=True)
+
+    assert result.returncode != 0
+    assert "Candidate header does not match schema" in result.stdout
+


### PR DESCRIPTION
## Summary
- Allow `load_schema` to read and combine multi-line schema files so all headers are captured
- Add tests for multi-line schema loading and header validation, including mismatch failure

## Testing
- `pytest repo/tools/test_compare_logs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb3fb1454832398f474661a1b5a6e