### PR TITLE
Fix order-insensitive row comparison in log tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,11 @@ MQL4/Include/*
 !repo/presets/
 !repo/presets/**
 
+# Tests
+!repo/tests/
+!repo/tests/**
+repo/tests/__pycache__/
+
 # Explicitly ignore volatile MT4 runtime stuff
 history/
 logs/

--- a/repo/tests/test_compare_logs.py
+++ b/repo/tests/test_compare_logs.py
@@ -1,0 +1,31 @@
+import subprocess, sys, textwrap, tempfile, pathlib
+
+def run_compare(baseline, candidate):
+    with tempfile.TemporaryDirectory() as d:
+        d_path = pathlib.Path(d)
+        b = d_path / 'baseline.csv'
+        c = d_path / 'candidate.csv'
+        b.write_text(textwrap.dedent(baseline).lstrip())
+        c.write_text(textwrap.dedent(candidate).lstrip())
+        result = subprocess.run(
+            [sys.executable, 'repo/tools/compare_logs.py', '--baseline', str(b), '--candidate', str(c)],
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+def test_swapped_order_identical_rows():
+    baseline = """\
+    timestamp,event,ticket,op,lots
+    1,trade,100,0,0.1
+    1,trade,100,0,0.2
+    """
+    candidate = """\
+    timestamp,event,ticket,op,lots
+    1,trade,100,0,0.2
+    1,trade,100,0,0.1
+    """
+    res = run_compare(baseline, candidate)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert 'RESULT: PASS' in res.stdout
+

--- a/repo/tools/compare_logs.py
+++ b/repo/tools/compare_logs.py
@@ -262,6 +262,11 @@ def main():
             if args.strict_rows:
                 mismatches += 1
                 continue
+        if b_list and c_list:
+            def _sort_key(row, header):
+                return tuple(row[i] if i < len(row) else "" for i, col in enumerate(header) if col not in key_cols)
+            b_list = sorted(b_list, key=lambda r: _sort_key(r, b_header))
+            c_list = sorted(c_list, key=lambda r: _sort_key(r, c_header))
         for i in range(min(len(b_list), len(c_list))):
             total += 1
             diffs = compare_rows(b_list[i], c_list[i], b_header, ignore_set,


### PR DESCRIPTION
## Summary
- ensure compare_logs handles row order by sorting non-key columns prior to comparison
- add regression test verifying swapped identical rows are treated as equal
- allow tests folder through gitignore

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb3f711248323bc30bc01350fc7e0