### PR TITLE
Add assertions to lots difference detection test

### DIFF
--- a/repo/tools/test_compare_logs.py
+++ b/repo/tools/test_compare_logs.py
@@ -82,6 +82,8 @@ def test_lots_difference_detected(tmp_path):
         "--schema", str(schema_path),
         "--align-key", "timestamp,event,ticket,op",
     ], capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "lots=0.1" in result.stdout and "lots=0.2" in result.stdout
 
 def test_duplicate_key_mismatched_lots_reports_diff(tmp_path):
     header = "timestamp,event,ticket,op,lots\n"


### PR DESCRIPTION
## Summary
- assert compare_logs non-zero return code when lots mismatch
- verify output shows both differing lot values

## Testing
- `pytest tools/test_compare_logs.py::test_lots_difference_detected -q --import-mode=importlib`

------
https://chatgpt.com/codex/tasks/task_e_68aeb9c06be4832386e35b9bcf3a3cd8