### PR TITLE
Ignore empty cells in log comparison

### DIFF
--- a/repo/tools/compare_logs.py
+++ b/repo/tools/compare_logs.py
@@ -114,6 +114,8 @@ def compare_rows(b_row, c_row, header, ignore_set,
             continue
         b = b_row[i] if i < len(b_row) else ""
         c = c_row[i] if i < len(c_row) else ""
+        if b.strip() == "" or c.strip() == "":
+            continue
         if b == c:
             continue
         bn = try_float(b)


### PR DESCRIPTION
## Summary
- avoid reporting diffs when baseline or candidate cell is empty before comparison

## Testing
- `pytest repo/tests/test_compare_logs.py -q`
- `python repo/tools/compare_logs.py --baseline /tmp/base.csv --candidate /tmp/cand.csv`


------
https://chatgpt.com/codex/tasks/task_e_68af97bfda0483239dac7405373c2f2f