### PR TITLE
Log basket TP assignment before modifying orders

### DIFF
--- a/MQL4/Experts/EuroScalper_CLEAN.mq4
+++ b/MQL4/Experts/EuroScalper_CLEAN.mq4
@@ -156,6 +156,10 @@ void ES_UpdateBasketTP()
    double tpdist = TakeProfit * Point;
    double basket_tp = NormalizeDouble((dir==OP_BUY) ? (vwap + tpdist) : (vwap - tpdist), _Digits);
 
+   // log assignment prior to issuing any order modifications so that
+   // `BASKET_TP_ASSIGN` precedes `ORDER_MODIFY_*` events in the log
+   ES_Log_Event_TPAssign(vwap, basket_tp);
+
    int total = OrdersTotal();
    for(int i=0; i<total; i++)
    {
@@ -168,19 +172,6 @@ void ES_UpdateBasketTP()
       double open_price = OrderOpenPrice();
       ES_Log_OrderModify(OrderTicket(), open_price, OrderStopLoss(), basket_tp, 0, 65535);
    }
-
-   // log the final TP as accepted by the server after modification
-   double final_tp = basket_tp;
-   for(int i=0; i<total; i++)
-   {
-      if(!OrderSelect(i, SELECT_BY_POS, MODE_TRADES)) continue;
-      if(OrderSymbol()!=Symbol())      continue;
-      if(OrderMagicNumber()!=Magic)    continue;
-      if(OrderType()!=dir)             continue;
-      final_tp = OrderTakeProfit();
-      break;
-   }
-   ES_Log_Event_TPAssign(vwap, final_tp);
 
    BasketTPUpdatePending = false;
 }


### PR DESCRIPTION
## Summary
- Log basket take-profit assignment before modifying existing orders
- Ensure BASKET_TP_ASSIGN precedes ORDER_MODIFY events to mirror baseline behavior

## Testing
- `python repo/tools/compare_logs.py --baseline repo/presets/backtests/EURUSD_2025.08.04_02_00_00_TO_2025.08.14_22_55_00_BASELINE.csv --candidate repo/presets/backtests/EURUSD_2025.08.04_02_00_00_TO_2025.08.14_19_13_37_CLEAN.csv --max-diffs 1 --no-rowcount` *(fails: mismatches remain while using existing logs)*

------
https://chatgpt.com/codex/tasks/task_e_68afc1439b788323b5892c914fcac148