### PR TITLE
Recompute first trade price before logging

### DIFF
--- a/MQL4/Experts/EuroScalper_CLEAN.mq4
+++ b/MQL4/Experts/EuroScalper_CLEAN.mq4
@@ -131,10 +131,10 @@ int ES_OpenFirstTrade()
    const int SLIPPAGE = 5; // baseline parity
 
    RefreshRates();
-   if(Close[2] > Close[1]) { cmd = OP_SELL; price = Bid; }
-   else                    { cmd = OP_BUY;  price = Ask; }
+   if(Close[2] > Close[1]) { cmd = OP_SELL; }
+   else                    { cmd = OP_BUY;  }
 
-   RefreshRates();
+   price = (cmd == OP_SELL) ? Bid : Ask;
    int ticket = (int)ES_Log_OrderSend(Symbol(), cmd, lots, price, SLIPPAGE,
                                  0, 0, StringConcatenate(Symbol(),"-Euro Scalper-0"), Magic, 0, clrNONE);
 


### PR DESCRIPTION
## Summary
- Recalculate initial trade price immediately after refreshing rates and remove redundant `RefreshRates` call.
- Log the order with the freshly sampled price to maintain accuracy.

## Testing
- `mql-compile MQL4/Experts/EuroScalper_CLEAN.mq4` *(fails: command not found)*
- `python repo/tools/compare_logs.py --baseline repo/presets/backtests/EURUSD_2025.08.04_02_00_00_TO_2025.08.14_22_55_00_BASELINE.csv --candidate repo/presets/backtests/EURUSD_2025.08.04_02_00_00_TO_2025.08.14_13_30_01_CLEAN.csv --align-key timestamp,ticket,order_type --ignore-cols floating_pl,closed_pl_today,vwap,basket_tp --float-tol-price 1e-6 --float-tol-money 1e-2 --max-diffs 5` *(fails: mismatches in price/timestamp)*

------
https://chatgpt.com/codex/tasks/task_e_68b10699b2ac8323991ef4f0a270eda1