### PR TITLE
Apply open-range filter only to initial trade

### DIFF
--- a/MQL4/Experts/EuroScalper_CLEAN.mq4
+++ b/MQL4/Experts/EuroScalper_CLEAN.mq4
@@ -93,8 +93,15 @@ bool ES_CanTrade_OpenRange()
 
 bool ES_CanTradeNow()
 {
-   if(!ES_CanTrade_Session())   return(false);
-   if(!ES_CanTrade_OpenRange()) return(false);
+   if(!ES_CanTrade_Session())
+      return(false);
+
+   // Evaluate the open-range filter only when no trades are open. Once a
+   // position exists, subsequent grid additions should ignore the
+   // open-range state, while still being gated by session hours.
+   if(OrdersTotal() == 0 && !ES_CanTrade_OpenRange())
+      return(false);
+
    return(true);
 }
 


### PR DESCRIPTION
## Summary
- Gate open-range checks to only run when no trades are open
- Preserve session gating on every tick and allow grid adds once a trade exists

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b1129d4ac083238228c7cbf85b9f00