### PR TITLE
Align modify order loop with baseline

### DIFF
--- a/MQL4/Experts/EuroScalper_CLEAN.mq4
+++ b/MQL4/Experts/EuroScalper_CLEAN.mq4
@@ -192,7 +192,8 @@ void ES_UpdateBasketTP()
    ES_Log_Event_TPAssign(vwap, basket_tp);
 
    int total = OrdersTotal();
-   for(int i=0; i<total; i++)
+   // iterate newest to oldest so ORDER_MODIFY_* entries align with baseline logs
+   for(int i = total - 1; i >= 0; i--)
    {
       if(!OrderSelect(i, SELECT_BY_POS, MODE_TRADES)) continue;
       if(OrderSymbol()!=Symbol())      continue;


### PR DESCRIPTION
## Summary
- revert prior lot-sizing changes to leave EA behavior unchanged
- iterate basket TP modification loop from newest to oldest so ORDER_MODIFY logs match baseline

## Testing
- `mql4 -q MQL4/Experts/EuroScalper_CLEAN.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b13182c6d083238219366ffdcd75a0