### PR TITLE
Fix compilation issues in EuroScalper MQL4 code

### DIFF
--- a/MQL4/Experts/EuroScalper_CLEAN.mq4
+++ b/MQL4/Experts/EuroScalper_CLEAN.mq4
@@ -46,10 +46,8 @@ double g_lastBuyPrice  = 0.0;   // price of most recent buy
 double g_lastSellPrice = 0.0;   // price of most recent sell
 bool   g_useVolFilter = true;   // mimic I_b_20 baseline behaviour
 bool   g_firstEntryArmed = true; // gate first entry until volume drop
-int    trade_counter = 0;        // -2 indicates rescue sizing
-
-int    trade_counter = -2;
-double next_lot = 0.0;
+int    trade_counter = -2;      // -2 indicates rescue sizing
+double next_lot    = 0.0;
 
 // ---- Session & Open-Range Gating ----
 bool ES_CanTrade_Session()
@@ -291,12 +289,12 @@ double ES_LastLotSize(const int cmd)
 
 double ES_RescueLotSize()
 {
-   double next_lot = Lot;
+   double rescue_lot = Lot;
 
    switch(RescueMode)
    {
       case 0:
-         next_lot = Lot;
+         rescue_lot = Lot;
          break;
 
       case 1:
@@ -304,15 +302,16 @@ double ES_RescueLotSize()
          {
             int count = ES_TotalTrades();
             if(count > 0)
-               next_lot = Lot * MathPow(LotMultiplikator, count);
+               rescue_lot = Lot * MathPow(LotMultiplikator, count);
             else
-               next_lot = Lot;
+               rescue_lot = Lot;
          }
          else
-            next_lot = Lot;
+            rescue_lot = Lot;
          break;
 
       case 2:
+      {
          double baseLot = Lot;
          int total = OrdersHistoryTotal();
          for(int i=total-1; i>=0; --i)
@@ -327,13 +326,14 @@ double ES_RescueLotSize()
             }
          }
          if(AddMultiplyFlag == 1)
-            next_lot = baseLot * LotMultiplikator;
+            rescue_lot = baseLot * LotMultiplikator;
          else
-            next_lot = baseLot + Lot;
+            rescue_lot = baseLot + Lot;
          break;
+      }
    }
 
-   return NormalizeDouble(next_lot, 2);
+   return NormalizeDouble(rescue_lot, 2);
 }
 
 double ES_NextLotSize(const int cmd)

--- a/MQL4/Include/ES_Logger.mqh
+++ b/MQL4/Include/ES_Logger.mqh
@@ -225,6 +225,7 @@ bool ES_Log_OrderModify(int ticket, double price, double stoploss, double takepr
    return ok;
 }
 
+#ifdef __MQL5__
 void OnTradeTransaction(const MqlTradeTransaction &trans,
                         const MqlTradeRequest &request,
                         const MqlTradeResult &result)
@@ -247,3 +248,4 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
       ES_Log_Write("ORDER_CLOSE_RESULT", ticket, op, lots, price, sl, tp, 0, 1, 0, reason);
    }
 }
+#endif // __MQL5__


### PR DESCRIPTION
## Summary
- Guard MQL5-only trade transaction logging with `__MQL5__` to avoid MQL4 compile errors
- Consolidate `trade_counter`/`next_lot` globals and refactor rescue lot sizing to remove shadowing and switch warnings

## Testing
- `metaeditor` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2916911a483239275918343b651bf